### PR TITLE
Fixed: Broken javascript src filepaths.

### DIFF
--- a/Web Page/Pages/Assistance Programs - ED3.html
+++ b/Web Page/Pages/Assistance Programs - ED3.html
@@ -19,7 +19,7 @@
 		<!-- <base href="http://www.ed3online.org/"> -->
 		<meta charset="utf-8">
 		<title>Assistance Programs | Electrical District #3</title>
-		<script type="text/javascript" src="./JS/Scroll%20Button.js"></script>
+		<script type="text/javascript" src="../JS/Scroll%20Button.js"></script>
 	</head>
 	
 	<!-- Background implemented -->

--- a/Web Page/Pages/Assistance Programs - ED3.html
+++ b/Web Page/Pages/Assistance Programs - ED3.html
@@ -55,9 +55,7 @@
 							<a href="../Index.html" class="w3-bar-item w3-button w3-hover-themea">Home</a>
 							<a href="./Location%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">Location</a>
 							<a href="./ED3%20History%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">History</a>
-							<a href="./Community%20Links%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">Community Links</a>
 							<a href="./Board%20Agenda%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">Board Adgenda</a>
-							<a href="./NEWS%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">News</a>	
 							</div>
 						</div>
 						<div class="w3-dropdown-hover w3-theme">
@@ -76,7 +74,7 @@
 							<button class="w3-button w3-theme w3-hover-themea">Information</button>
 							<div class="w3-dropdown-content w3-bar-block w3-card-4 w3-theme w3-border-theme">
 							<a href="./Rates%20and%20Guidelines%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Rates & Guide Lines</a>
-							<a href="./Energy%20Saving%20Tips%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Energy Saving Tips</a>
+							<a href="./Energy%20Saving%20Tips%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Tips & Information</a>
 							<a href="./Blue%20Staking%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Blue Stakes</a>
 							<a href="./Meter%20Read%20Dates/Meter%20Read%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Meter Read Dates</a>
 							<a href="./Solar%20Power%20Program%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Solar Power Program</a>
@@ -86,20 +84,26 @@
 							</div>
 						</div>
 						<div class="w3-dropdown-hover w3-theme">
+							<button class="w3-button w3-theme w3-hover-themea">Community</button>
+							<div class="w3-dropdown-content w3-bar-block w3-card-4 w3-theme w3-border-theme">
+							<a href="./Assistance%20Programs%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Assistance Programs</a>
+							<a href="./Community%20Links%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">Community Links</a>
+							<a href="./NEWS%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">News</a>	
+							</div>
+						</div>
+						<div class="w3-dropdown-hover w3-theme">
 							<button class="w3-button w3-theme w3-hover-themea">Contact Us</button>
 							<div class="w3-dropdown-content w3-bar-block w3-card-4 w3-theme w3-border-theme">
 							<a href="./Contact%20Us%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Contact Us</a>
 							<a href="./Prevent%20Power%20Theft%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Power Theft</a>
-							<a href="./Assistance%20Programs%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Assistance Programs</a>
 							<a href="./Questions%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Questions</a>
 							<a href="./Employment%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Employment</a>
 							<a href="./Street%20Light%20Repair%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Street Light Repair</a>
 							</div>
 						</div>
-					
-					
 					</div>
 			<!-- End page navigation -->
+			
 			<!--- left side of page begin --->
 			<article class="w3-container w3-quarter w3-theme">
 			</article>

--- a/Web Page/Pages/Board Agenda - ED3.html
+++ b/Web Page/Pages/Board Agenda - ED3.html
@@ -47,6 +47,7 @@
 			
 			</header>
 			<!--End Top of page Set up-->
+			
 			<!-- Start page navigation -->
 					<div class="w3-bar w3-theme">
 						<div class="w3-dropdown-hover w3-theme">
@@ -55,9 +56,7 @@
 							<a href="../Index.html" class="w3-bar-item w3-button w3-hover-themea">Home</a>
 							<a href="./Location%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">Location</a>
 							<a href="./ED3%20History%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">History</a>
-							<a href="./Community%20Links%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">Community Links</a>
 							<a href="./Board%20Agenda%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">Board Adgenda</a>
-							<a href="./NEWS%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">News</a>	
 							</div>
 						</div>
 						<div class="w3-dropdown-hover w3-theme">
@@ -76,7 +75,7 @@
 							<button class="w3-button w3-theme w3-hover-themea">Information</button>
 							<div class="w3-dropdown-content w3-bar-block w3-card-4 w3-theme w3-border-theme">
 							<a href="./Rates%20and%20Guidelines%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Rates & Guide Lines</a>
-							<a href="./Energy%20Saving%20Tips%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Energy Saving Tips</a>
+							<a href="./Energy%20Saving%20Tips%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Tips & Information</a>
 							<a href="./Blue%20Staking%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Blue Stakes</a>
 							<a href="./Meter%20Read%20Dates/Meter%20Read%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Meter Read Dates</a>
 							<a href="./Solar%20Power%20Program%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Solar Power Program</a>
@@ -86,20 +85,26 @@
 							</div>
 						</div>
 						<div class="w3-dropdown-hover w3-theme">
+							<button class="w3-button w3-theme w3-hover-themea">Community</button>
+							<div class="w3-dropdown-content w3-bar-block w3-card-4 w3-theme w3-border-theme">
+							<a href="./Assistance%20Programs%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Assistance Programs</a>
+							<a href="./Community%20Links%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">Community Links</a>
+							<a href="./NEWS%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">News</a>	
+							</div>
+						</div>
+						<div class="w3-dropdown-hover w3-theme">
 							<button class="w3-button w3-theme w3-hover-themea">Contact Us</button>
 							<div class="w3-dropdown-content w3-bar-block w3-card-4 w3-theme w3-border-theme">
 							<a href="./Contact%20Us%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Contact Us</a>
 							<a href="./Prevent%20Power%20Theft%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Power Theft</a>
-							<a href="./Assistance%20Programs%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Assistance Programs</a>
 							<a href="./Questions%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Questions</a>
 							<a href="./Employment%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Employment</a>
 							<a href="./Street%20Light%20Repair%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Street Light Repair</a>
 							</div>
 						</div>
-					
-					
 					</div>
 			<!-- End page navigation -->
+			
 			<!--- left side of page begin --->
 			<article class="w3-container w3-quarter w3-theme">
 			</article>

--- a/Web Page/Pages/Board Agenda - ED3.html
+++ b/Web Page/Pages/Board Agenda - ED3.html
@@ -19,7 +19,7 @@
 		<!-- <base href="http://www.ed3online.org/"> -->
 		<meta charset="utf-8">
 		<title>Board Agenda | Electrical District #3</title>
-		<script type="text/javascript" src="./JS/Scroll%20Button.js"></script>
+		<script type="text/javascript" src="../JS/Scroll%20Button.js"></script>
 	</head>
 	
 	<!-- Background implemented -->

--- a/Web Page/Pages/Contact Us - ED3.html
+++ b/Web Page/Pages/Contact Us - ED3.html
@@ -47,6 +47,7 @@
 			
 			</header>
 			<!--End Top of page Set up-->
+			
 			<!-- Start page navigation -->
 					<div class="w3-bar w3-theme">
 						<div class="w3-dropdown-hover w3-theme">
@@ -55,9 +56,7 @@
 							<a href="../Index.html" class="w3-bar-item w3-button w3-hover-themea">Home</a>
 							<a href="./Location%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">Location</a>
 							<a href="./ED3%20History%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">History</a>
-							<a href="./Community%20Links%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">Community Links</a>
 							<a href="./Board%20Agenda%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">Board Adgenda</a>
-							<a href="./NEWS%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">News</a>	
 							</div>
 						</div>
 						<div class="w3-dropdown-hover w3-theme">
@@ -76,7 +75,7 @@
 							<button class="w3-button w3-theme w3-hover-themea">Information</button>
 							<div class="w3-dropdown-content w3-bar-block w3-card-4 w3-theme w3-border-theme">
 							<a href="./Rates%20and%20Guidelines%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Rates & Guide Lines</a>
-							<a href="./Energy%20Saving%20Tips%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Energy Saving Tips</a>
+							<a href="./Energy%20Saving%20Tips%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Tips & Information</a>
 							<a href="./Blue%20Staking%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Blue Stakes</a>
 							<a href="./Meter%20Read%20Dates/Meter%20Read%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Meter Read Dates</a>
 							<a href="./Solar%20Power%20Program%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Solar Power Program</a>
@@ -86,20 +85,26 @@
 							</div>
 						</div>
 						<div class="w3-dropdown-hover w3-theme">
+							<button class="w3-button w3-theme w3-hover-themea">Community</button>
+							<div class="w3-dropdown-content w3-bar-block w3-card-4 w3-theme w3-border-theme">
+							<a href="./Assistance%20Programs%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Assistance Programs</a>
+							<a href="./Community%20Links%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">Community Links</a>
+							<a href="./NEWS%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">News</a>	
+							</div>
+						</div>
+						<div class="w3-dropdown-hover w3-theme">
 							<button class="w3-button w3-theme w3-hover-themea">Contact Us</button>
 							<div class="w3-dropdown-content w3-bar-block w3-card-4 w3-theme w3-border-theme">
 							<a href="./Contact%20Us%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Contact Us</a>
 							<a href="./Prevent%20Power%20Theft%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Power Theft</a>
-							<a href="./Assistance%20Programs%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Assistance Programs</a>
 							<a href="./Questions%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Questions</a>
 							<a href="./Employment%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Employment</a>
 							<a href="./Street%20Light%20Repair%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Street Light Repair</a>
 							</div>
 						</div>
-					
-					
 					</div>
 			<!-- End page navigation -->
+			
 			<!--- left side of page begin --->
 			<article class="w3-container w3-quarter w3-theme">
 			</article>

--- a/Web Page/Pages/NEWS - ED3.html
+++ b/Web Page/Pages/NEWS - ED3.html
@@ -47,6 +47,7 @@
 			
 			</header>
 			<!--End Top of page Set up-->
+			
 			<!-- Start page navigation -->
 					<div class="w3-bar w3-theme">
 						<div class="w3-dropdown-hover w3-theme">
@@ -55,9 +56,7 @@
 							<a href="../Index.html" class="w3-bar-item w3-button w3-hover-themea">Home</a>
 							<a href="./Location%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">Location</a>
 							<a href="./ED3%20History%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">History</a>
-							<a href="./Community%20Links%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">Community Links</a>
 							<a href="./Board%20Agenda%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">Board Adgenda</a>
-							<a href="./NEWS%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">News</a>	
 							</div>
 						</div>
 						<div class="w3-dropdown-hover w3-theme">
@@ -76,7 +75,7 @@
 							<button class="w3-button w3-theme w3-hover-themea">Information</button>
 							<div class="w3-dropdown-content w3-bar-block w3-card-4 w3-theme w3-border-theme">
 							<a href="./Rates%20and%20Guidelines%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Rates & Guide Lines</a>
-							<a href="./Energy%20Saving%20Tips%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Energy Saving Tips</a>
+							<a href="./Energy%20Saving%20Tips%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Tips & Information</a>
 							<a href="./Blue%20Staking%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Blue Stakes</a>
 							<a href="./Meter%20Read%20Dates/Meter%20Read%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Meter Read Dates</a>
 							<a href="./Solar%20Power%20Program%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Solar Power Program</a>
@@ -86,20 +85,26 @@
 							</div>
 						</div>
 						<div class="w3-dropdown-hover w3-theme">
+							<button class="w3-button w3-theme w3-hover-themea">Community</button>
+							<div class="w3-dropdown-content w3-bar-block w3-card-4 w3-theme w3-border-theme">
+							<a href="./Assistance%20Programs%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Assistance Programs</a>
+							<a href="./Community%20Links%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">Community Links</a>
+							<a href="./NEWS%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">News</a>	
+							</div>
+						</div>
+						<div class="w3-dropdown-hover w3-theme">
 							<button class="w3-button w3-theme w3-hover-themea">Contact Us</button>
 							<div class="w3-dropdown-content w3-bar-block w3-card-4 w3-theme w3-border-theme">
 							<a href="./Contact%20Us%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Contact Us</a>
 							<a href="./Prevent%20Power%20Theft%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Power Theft</a>
-							<a href="./Assistance%20Programs%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Assistance Programs</a>
 							<a href="./Questions%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Questions</a>
 							<a href="./Employment%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Employment</a>
 							<a href="./Street%20Light%20Repair%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Street Light Repair</a>
 							</div>
 						</div>
-					
-					
 					</div>
 			<!-- End page navigation -->
+			
 			<!--- left side of page begin --->
 			<article class="w3-container w3-quarter w3-theme">
 			</article>

--- a/Web Page/Pages/NEWS - ED3.html
+++ b/Web Page/Pages/NEWS - ED3.html
@@ -19,7 +19,7 @@
 		<!-- <base href="http://www.ed3online.org/"> -->
 		<meta charset="utf-8">
 		<title>News | Electrical District #3</title>
-		<script type="text/javascript" src="./JS/Scroll%20Button.js"></script>
+		<script type="text/javascript" src="../JS/Scroll%20Button.js"></script>
 	</head>
 	
 	<!-- Background implemented -->

--- a/Web Page/Pages/Prevent Power Theft - ED3.html
+++ b/Web Page/Pages/Prevent Power Theft - ED3.html
@@ -47,6 +47,7 @@
 			
 			</header>
 			<!--End Top of page Set up-->
+			
 			<!-- Start page navigation -->
 					<div class="w3-bar w3-theme">
 						<div class="w3-dropdown-hover w3-theme">
@@ -55,9 +56,7 @@
 							<a href="../Index.html" class="w3-bar-item w3-button w3-hover-themea">Home</a>
 							<a href="./Location%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">Location</a>
 							<a href="./ED3%20History%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">History</a>
-							<a href="./Community%20Links%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">Community Links</a>
 							<a href="./Board%20Agenda%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">Board Adgenda</a>
-							<a href="./NEWS%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">News</a>	
 							</div>
 						</div>
 						<div class="w3-dropdown-hover w3-theme">
@@ -76,7 +75,7 @@
 							<button class="w3-button w3-theme w3-hover-themea">Information</button>
 							<div class="w3-dropdown-content w3-bar-block w3-card-4 w3-theme w3-border-theme">
 							<a href="./Rates%20and%20Guidelines%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Rates & Guide Lines</a>
-							<a href="./Energy%20Saving%20Tips%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Energy Saving Tips</a>
+							<a href="./Energy%20Saving%20Tips%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Tips & Information</a>
 							<a href="./Blue%20Staking%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Blue Stakes</a>
 							<a href="./Meter%20Read%20Dates/Meter%20Read%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Meter Read Dates</a>
 							<a href="./Solar%20Power%20Program%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Solar Power Program</a>
@@ -86,20 +85,26 @@
 							</div>
 						</div>
 						<div class="w3-dropdown-hover w3-theme">
+							<button class="w3-button w3-theme w3-hover-themea">Community</button>
+							<div class="w3-dropdown-content w3-bar-block w3-card-4 w3-theme w3-border-theme">
+							<a href="./Assistance%20Programs%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Assistance Programs</a>
+							<a href="./Community%20Links%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">Community Links</a>
+							<a href="./NEWS%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">News</a>	
+							</div>
+						</div>
+						<div class="w3-dropdown-hover w3-theme">
 							<button class="w3-button w3-theme w3-hover-themea">Contact Us</button>
 							<div class="w3-dropdown-content w3-bar-block w3-card-4 w3-theme w3-border-theme">
 							<a href="./Contact%20Us%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Contact Us</a>
 							<a href="./Prevent%20Power%20Theft%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Power Theft</a>
-							<a href="./Assistance%20Programs%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Assistance Programs</a>
 							<a href="./Questions%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Questions</a>
 							<a href="./Employment%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Employment</a>
 							<a href="./Street%20Light%20Repair%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Street Light Repair</a>
 							</div>
 						</div>
-					
-					
 					</div>
 			<!-- End page navigation -->
+			
 			<!--- left side of page begin --->
 			<article class="w3-container w3-quarter w3-theme">
 			</article>

--- a/Web Page/Pages/Prevent Power Theft - ED3.html
+++ b/Web Page/Pages/Prevent Power Theft - ED3.html
@@ -19,7 +19,7 @@
 		<!-- <base href="http://www.ed3online.org/"> -->
 		<meta charset="utf-8">
 		<title>Power Theft Prevention | Electrical District #3</title>
-		<script type="text/javascript" src="./JS/Scroll%20Button.js"></script>
+		<script type="text/javascript" src="../JS/Scroll%20Button.js"></script>
 	</head>
 	
 	<!-- Background implemented -->

--- a/Web Page/Pages/Questions - ED3.html
+++ b/Web Page/Pages/Questions - ED3.html
@@ -47,6 +47,7 @@
 			
 			</header>
 			<!--End Top of page Set up-->
+			
 			<!-- Start page navigation -->
 					<div class="w3-bar w3-theme">
 						<div class="w3-dropdown-hover w3-theme">
@@ -55,9 +56,7 @@
 							<a href="../Index.html" class="w3-bar-item w3-button w3-hover-themea">Home</a>
 							<a href="./Location%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">Location</a>
 							<a href="./ED3%20History%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">History</a>
-							<a href="./Community%20Links%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">Community Links</a>
 							<a href="./Board%20Agenda%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">Board Adgenda</a>
-							<a href="./NEWS%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">News</a>	
 							</div>
 						</div>
 						<div class="w3-dropdown-hover w3-theme">
@@ -76,7 +75,7 @@
 							<button class="w3-button w3-theme w3-hover-themea">Information</button>
 							<div class="w3-dropdown-content w3-bar-block w3-card-4 w3-theme w3-border-theme">
 							<a href="./Rates%20and%20Guidelines%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Rates & Guide Lines</a>
-							<a href="./Energy%20Saving%20Tips%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Energy Saving Tips</a>
+							<a href="./Energy%20Saving%20Tips%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Tips & Information</a>
 							<a href="./Blue%20Staking%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Blue Stakes</a>
 							<a href="./Meter%20Read%20Dates/Meter%20Read%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Meter Read Dates</a>
 							<a href="./Solar%20Power%20Program%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Solar Power Program</a>
@@ -86,20 +85,26 @@
 							</div>
 						</div>
 						<div class="w3-dropdown-hover w3-theme">
+							<button class="w3-button w3-theme w3-hover-themea">Community</button>
+							<div class="w3-dropdown-content w3-bar-block w3-card-4 w3-theme w3-border-theme">
+							<a href="./Assistance%20Programs%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Assistance Programs</a>
+							<a href="./Community%20Links%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">Community Links</a>
+							<a href="./NEWS%20-%20ED3.html" class="w3-bar-item w3-button w3-hover-themea">News</a>	
+							</div>
+						</div>
+						<div class="w3-dropdown-hover w3-theme">
 							<button class="w3-button w3-theme w3-hover-themea">Contact Us</button>
 							<div class="w3-dropdown-content w3-bar-block w3-card-4 w3-theme w3-border-theme">
 							<a href="./Contact%20Us%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Contact Us</a>
 							<a href="./Prevent%20Power%20Theft%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Power Theft</a>
-							<a href="./Assistance%20Programs%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Assistance Programs</a>
 							<a href="./Questions%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Questions</a>
 							<a href="./Employment%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Employment</a>
 							<a href="./Street%20Light%20Repair%20-%20ED3.html"class="w3-bar-item w3-button w3-hover-themea">Street Light Repair</a>
 							</div>
 						</div>
-					
-					
 					</div>
 			<!-- End page navigation -->
+			
 			<!--- left side of page begin --->
 			<article class="w3-container w3-quarter w3-theme">
 			</article>

--- a/Web Page/Pages/Questions - ED3.html
+++ b/Web Page/Pages/Questions - ED3.html
@@ -19,7 +19,7 @@
 		<!-- <base href="http://www.ed3online.org/"> -->
 		<meta charset="utf-8">
 		<title>Questions | Electrical District #3</title>
-		<script type="text/javascript" src="./JS/Scroll%20Button.js"></script>
+		<script type="text/javascript" src="../JS/Scroll%20Button.js"></script>
 	</head>
 	
 	<!-- Background implemented -->


### PR DESCRIPTION
Several HTML pages were incorrectly referencing the current folder instead of the parent folder in src paths, and thus were unable to find the JS folder.

Updated the src paths to allow the pages to correctly locate the javascript folder and files.
Old: src="./JS"
New: src="../JS"